### PR TITLE
feat: Adicionar endpoint /api/v1/installer/validate para sistema de instalador customizado

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -131,7 +131,10 @@ if (in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
         '/api/deactivate_license',
         '/api/check_connection_ext',
         '/api/latest_version',
-        '/api/check_update'
+        '/api/check_update',
+        
+        // Novo endpoint de instalador customizado
+        '/api/v1/installer/validate'
     ];
     
     if (!in_array($path, $csrfExempt)) {
@@ -234,6 +237,17 @@ try {
             'success' => true,
             'csrf_token' => $_SESSION['_token']
         ]);
+        exit;
+    }
+    
+    // ===========================
+    // NOVO ENDPOINT INSTALADOR CUSTOMIZADO
+    // Usado por 28Salon/28Pro com instalador customizado
+    // ===========================
+    
+    if ($path === '/api/v1/installer/validate' && $method === 'POST') {
+        $controller = new LicenseController($db);
+        echo json_encode($controller->installerValidate(), JSON_PRETTY_PRINT);
         exit;
     }
     
@@ -569,6 +583,7 @@ function healthCheck() {
         'features' => [
             'licensing' => 'enabled',
             'licensebox_compatibility' => 'enabled',
+            'custom_installer' => 'enabled',
             'portal' => 'enabled',
             'users' => 'enabled',
             'api_keys' => 'enabled',
@@ -581,6 +596,9 @@ function healthCheck() {
             'rate_limiting' => 'client-side'
         ],
         'endpoints' => [
+            'installer_custom' => [
+                'validate' => ['method' => 'POST', 'path' => '/api/v1/installer/validate', 'auth' => 'public', 'description' => 'Validate license for custom installer (28Salon/28Pro)']
+            ],
             'licensing_28pro' => [
                 'validate' => ['method' => 'POST', 'path' => '/api/license/validate', 'auth' => 'public'],
                 'activate' => ['method' => 'POST', 'path' => '/api/license/activate', 'auth' => 'public'],


### PR DESCRIPTION
## Descrição

Implementa novo endpoint `/api/v1/installer/validate` para suportar sistema de instalador customizado usado em produtos como 28Salon e 28Pro.

## Mudanças Realizadas

### 1. **Novo Método no LicenseController**
- Adicionado método `installerValidate()` em `src/Controllers/LicenseController.php`
- Aceita payload JSON com:
  - `productkey`: Chave de licença (purchase_code)
  - `client`: URL da instalação
  - `version`: Versão do sistema
  - `timestamp`: ISO 8601

### 2. **Nova Rota Pública**
- Adicionada rota `POST /api/v1/installer/validate` em `public/index.php`
- Rota isenta de CSRF protection (API pública)
- Endpoint documentado no health check (`GET /health`)

### 3. **Respostas do Endpoint**

#### Sucesso (200 OK)
```json
{
  "valid": true,
  "message": "Licença válida",
  "licensetype": "lifetime",
  "expires_at": null,
  "features": ["all"],
  "license_key_info": {
    "key": "XXXX-****-****-XXXX",
    "type": "lifetime",
    "max_sites": 1
  }
}
```

#### Licença Inválida (404)
```json
{
  "valid": false,
  "message": "Chave de licença não encontrada. Entre em contato com o suporte."
}
```

#### Licença Expirada (403)
```json
{
  "valid": false,
  "message": "Licença expirada em 25/12/2025. Entre em contato para renovação."
}
```

## Compatibilidade

- ✅ Compatível com sistema de instalador customizado
- ✅ Não quebra endpoints existentes
- ✅ Documentação automática no `/health`
- ✅ Logs de debug para troubleshooting

## Testes Sugeridos

1. Testar com chave válida:
```bash
curl -X POST https://api.28facil.com.br/api/v1/installer/validate \
  -H "Content-Type: application/json" \
  -d '{
    "productkey": "XXXX-XXXX-XXXX-XXXX",
    "client": "https://exemplo.com",
    "version": "1.6.0",
    "timestamp": "2026-01-25T14:00:00Z"
  }'
```

2. Testar com chave inválida
3. Testar com chave expirada
4. Verificar logs no servidor

## Documentação

Endpoint documentado conforme especificação em `docs/replace-licensing-system.md`.

## Checklist

- [x] Código segue padrões do projeto
- [x] Endpoint isento de CSRF (API pública)
- [x] Logs de debug implementados
- [x] Health check atualizado
- [x] Documentado no README (se necessário)
- [ ] Testado em ambiente de desenvolvimento
- [ ] Testado em ambiente de produção